### PR TITLE
JIS -> UTF変換ツール改修：文字列置換機能を追加する

### DIFF
--- a/components/StringReplacement.js
+++ b/components/StringReplacement.js
@@ -1,0 +1,329 @@
+import { useState } from 'react';
+import styles from './StringReplacement.module.css';
+
+export const StringReplacement = ({ 
+  replacementRules, 
+  error,
+  onAddRule, 
+  onUpdateRule, 
+  onDeleteRule, 
+  onToggleRule,
+  onToggleAllRules,
+  onReorderRules,
+  onClearAllRules,
+  onClearError
+}) => {
+  const [showAddForm, setShowAddForm] = useState(false);
+  const [editingRule, setEditingRule] = useState(null);
+
+  const handleAddRule = () => {
+    setShowAddForm(true);
+    setEditingRule(null);
+    onClearError();
+  };
+
+  const handleEditRule = (rule) => {
+    setEditingRule(rule);
+    setShowAddForm(false);
+    onClearError();
+  };
+
+  const handleCancelEdit = () => {
+    setEditingRule(null);
+    setShowAddForm(false);
+    onClearError();
+  };
+
+  const handleMoveUp = (index) => {
+    if (index > 0) {
+      onReorderRules(index, index - 1);
+    }
+  };
+
+  const handleMoveDown = (index) => {
+    if (index < replacementRules.length - 1) {
+      onReorderRules(index, index + 1);
+    }
+  };
+
+  const enabledRulesCount = replacementRules.filter(rule => rule.isEnabled).length;
+  const hasRules = replacementRules.length > 0;
+
+  return (
+    <div className={styles.replacementSection}>
+      <div className={styles.header}>
+        <h3 className={styles.title}>文字列置換設定</h3>
+        {hasRules && (
+          <div className={styles.summary}>
+            {enabledRulesCount} / {replacementRules.length} ルールが有効
+          </div>
+        )}
+      </div>
+
+      {error && (
+        <div className={styles.error}>
+          {error}
+          <button onClick={onClearError} className={styles.errorClose}>×</button>
+        </div>
+      )}
+
+      {/* 置換ルール一覧 */}
+      {hasRules && (
+        <div className={styles.rulesList}>
+          <div className={styles.rulesHeader}>
+            <span>置換ルール（上から順に適用）</span>
+            <div className={styles.bulkActions}>
+              <button 
+                onClick={() => onToggleAllRules(true)}
+                className={styles.bulkButton}
+                disabled={enabledRulesCount === replacementRules.length}
+              >
+                全て有効
+              </button>
+              <button 
+                onClick={() => onToggleAllRules(false)}
+                className={styles.bulkButton}
+                disabled={enabledRulesCount === 0}
+              >
+                全て無効
+              </button>
+              <button 
+                onClick={onClearAllRules}
+                className={styles.bulkButtonDanger}
+              >
+                全て削除
+              </button>
+            </div>
+          </div>
+          
+          {replacementRules.map((rule, index) => (
+            <RuleItem 
+              key={rule.id}
+              rule={rule}
+              index={index}
+              isFirst={index === 0}
+              isLast={index === replacementRules.length - 1}
+              isEditing={editingRule?.id === rule.id}
+              onEdit={handleEditRule}
+              onUpdate={onUpdateRule}
+              onDelete={onDeleteRule}
+              onToggle={onToggleRule}
+              onMoveUp={handleMoveUp}
+              onMoveDown={handleMoveDown}
+              onCancelEdit={handleCancelEdit}
+            />
+          ))}
+        </div>
+      )}
+
+      {/* 置換設定が空の場合の表示 */}
+      {!hasRules && (
+        <div className={styles.emptyState}>
+          <div className={styles.emptyIcon}>📝</div>
+          <h4>文字列置換ルールが設定されていません</h4>
+          <p>CSVファイルの文字列を置換するルールを追加してください</p>
+        </div>
+      )}
+
+      {/* 新しいルール追加フォーム */}
+      {showAddForm && (
+        <AddRuleForm 
+          onAdd={onAddRule}
+          onCancel={handleCancelEdit}
+        />
+      )}
+
+      {/* 追加ボタン */}
+      {!showAddForm && !editingRule && (
+        <button 
+          onClick={handleAddRule}
+          className={styles.addButton}
+        >
+          + 新しい置換ルールを追加
+        </button>
+      )}
+    </div>
+  );
+};
+
+// 個別のルールアイテムコンポーネント
+const RuleItem = ({ 
+  rule, 
+  index, 
+  isFirst, 
+  isLast, 
+  isEditing, 
+  onEdit, 
+  onUpdate, 
+  onDelete, 
+  onToggle, 
+  onMoveUp, 
+  onMoveDown, 
+  onCancelEdit 
+}) => {
+  if (isEditing) {
+    return (
+      <EditRuleForm 
+        rule={rule}
+        onUpdate={onUpdate}
+        onCancel={onCancelEdit}
+      />
+    );
+  }
+
+  return (
+    <div className={`${styles.ruleItem} ${!rule.isEnabled ? styles.disabled : ''}`}>
+      <div className={styles.ruleContent}>
+        <div className={styles.ruleOrder}>
+          {index + 1}
+        </div>
+        <div className={styles.ruleText}>
+          <div className={styles.searchText}>
+            <strong>検索:</strong> "{rule.searchText}"
+          </div>
+          <div className={styles.replaceText}>
+            <strong>置換:</strong> "{rule.replaceText || '(削除)'}"
+          </div>
+        </div>
+        <div className={styles.ruleActions}>
+          <button
+            onClick={() => onToggle(rule.id)}
+            className={`${styles.toggleButton} ${rule.isEnabled ? styles.enabled : styles.disabled}`}
+          >
+            {rule.isEnabled ? '有効' : '無効'}
+          </button>
+          <button
+            onClick={() => onEdit(rule)}
+            className={styles.editButton}
+          >
+            編集
+          </button>
+          <div className={styles.moveButtons}>
+            <button
+              onClick={() => onMoveUp(index)}
+              disabled={isFirst}
+              className={styles.moveButton}
+            >
+              ↑
+            </button>
+            <button
+              onClick={() => onMoveDown(index)}
+              disabled={isLast}
+              className={styles.moveButton}
+            >
+              ↓
+            </button>
+          </div>
+          <button
+            onClick={() => onDelete(rule.id)}
+            className={styles.deleteButton}
+          >
+            削除
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+// 新しいルール追加フォーム
+const AddRuleForm = ({ onAdd, onCancel }) => {
+  const [searchText, setSearchText] = useState('');
+  const [replaceText, setReplaceText] = useState('');
+
+  const handleSubmit = (e) => {
+    e.preventDefault();
+    if (onAdd(searchText, replaceText)) {
+      setSearchText('');
+      setReplaceText('');
+      onCancel();
+    }
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className={styles.ruleForm}>
+      <h4>新しい置換ルールを追加</h4>
+      <div className={styles.formGroup}>
+        <label htmlFor="searchText">検索する文字列 *</label>
+        <input
+          id="searchText"
+          type="text"
+          value={searchText}
+          onChange={(e) => setSearchText(e.target.value)}
+          placeholder="置換したい文字列を入力"
+          className={styles.input}
+          required
+        />
+      </div>
+      <div className={styles.formGroup}>
+        <label htmlFor="replaceText">置換後の文字列</label>
+        <input
+          id="replaceText"
+          type="text"
+          value={replaceText}
+          onChange={(e) => setReplaceText(e.target.value)}
+          placeholder="置換後の文字列を入力（空の場合は削除）"
+          className={styles.input}
+        />
+      </div>
+      <div className={styles.formActions}>
+        <button type="submit" className={styles.submitButton}>
+          追加
+        </button>
+        <button type="button" onClick={onCancel} className={styles.cancelButton}>
+          キャンセル
+        </button>
+      </div>
+    </form>
+  );
+};
+
+// ルール編集フォーム
+const EditRuleForm = ({ rule, onUpdate, onCancel }) => {
+  const [searchText, setSearchText] = useState(rule.searchText);
+  const [replaceText, setReplaceText] = useState(rule.replaceText);
+
+  const handleSubmit = (e) => {
+    e.preventDefault();
+    if (onUpdate(rule.id, searchText, replaceText)) {
+      onCancel();
+    }
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className={styles.ruleForm}>
+      <h4>置換ルールを編集</h4>
+      <div className={styles.formGroup}>
+        <label htmlFor="editSearchText">検索する文字列 *</label>
+        <input
+          id="editSearchText"
+          type="text"
+          value={searchText}
+          onChange={(e) => setSearchText(e.target.value)}
+          placeholder="置換したい文字列を入力"
+          className={styles.input}
+          required
+        />
+      </div>
+      <div className={styles.formGroup}>
+        <label htmlFor="editReplaceText">置換後の文字列</label>
+        <input
+          id="editReplaceText"
+          type="text"
+          value={replaceText}
+          onChange={(e) => setReplaceText(e.target.value)}
+          placeholder="置換後の文字列を入力（空の場合は削除）"
+          className={styles.input}
+        />
+      </div>
+      <div className={styles.formActions}>
+        <button type="submit" className={styles.submitButton}>
+          更新
+        </button>
+        <button type="button" onClick={onCancel} className={styles.cancelButton}>
+          キャンセル
+        </button>
+      </div>
+    </form>
+  );
+}; 

--- a/components/StringReplacement.module.css
+++ b/components/StringReplacement.module.css
@@ -1,0 +1,463 @@
+/* メインセクション */
+.replacementSection {
+  background: white;
+  border-radius: 12px;
+  padding: 1.5rem;
+  box-shadow: var(--shadow-md);
+  margin-bottom: 2rem;
+  width: 100%;
+  max-width: 800px;
+}
+
+/* ヘッダー */
+.header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 1.5rem;
+  padding-bottom: 1rem;
+  border-bottom: 1px solid var(--gray-200);
+}
+
+.title {
+  margin: 0;
+  font-size: 1.25rem;
+  font-weight: 600;
+  color: var(--gray-900);
+}
+
+.summary {
+  font-size: 0.875rem;
+  color: var(--gray-500);
+  background-color: var(--gray-100);
+  padding: 0.25rem 0.75rem;
+  border-radius: 20px;
+}
+
+/* エラー表示 */
+.error {
+  background-color: #fee2e2;
+  border: 1px solid #fecaca;
+  color: var(--danger-color);
+  padding: 1rem;
+  border-radius: 8px;
+  margin-bottom: 1rem;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  animation: fadeIn 0.3s ease;
+}
+
+.errorClose {
+  background: none;
+  border: none;
+  color: var(--danger-color);
+  font-size: 1.25rem;
+  cursor: pointer;
+  padding: 0;
+  width: 24px;
+  height: 24px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 50%;
+  transition: var(--transition);
+}
+
+.errorClose:hover {
+  background-color: var(--danger-color);
+  color: white;
+}
+
+/* 空の状態 */
+.emptyState {
+  text-align: center;
+  padding: 3rem 2rem;
+  color: var(--gray-500);
+}
+
+.emptyIcon {
+  font-size: 3rem;
+  margin-bottom: 1rem;
+}
+
+.emptyState h4 {
+  margin: 0 0 0.5rem 0;
+  font-size: 1.125rem;
+  color: var(--gray-700);
+}
+
+.emptyState p {
+  margin: 0;
+  font-size: 0.875rem;
+}
+
+/* ルール一覧 */
+.rulesList {
+  margin-bottom: 1.5rem;
+}
+
+.rulesHeader {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 1rem;
+  padding: 0.75rem 1rem;
+  background-color: var(--gray-50);
+  border-radius: 8px;
+  font-size: 0.875rem;
+  font-weight: 500;
+  color: var(--gray-700);
+}
+
+.bulkActions {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.bulkButton {
+  padding: 0.375rem 0.75rem;
+  border: 1px solid var(--gray-300);
+  background-color: white;
+  color: var(--gray-700);
+  border-radius: 6px;
+  font-size: 0.75rem;
+  cursor: pointer;
+  transition: var(--transition);
+}
+
+.bulkButton:hover:not(:disabled) {
+  background-color: var(--gray-50);
+  border-color: var(--gray-400);
+}
+
+.bulkButton:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.bulkButtonDanger {
+  padding: 0.375rem 0.75rem;
+  border: 1px solid var(--danger-color);
+  background-color: var(--danger-color);
+  color: white;
+  border-radius: 6px;
+  font-size: 0.75rem;
+  cursor: pointer;
+  transition: var(--transition);
+}
+
+.bulkButtonDanger:hover {
+  background-color: var(--danger-hover);
+  border-color: var(--danger-hover);
+}
+
+/* ルールアイテム */
+.ruleItem {
+  border: 1px solid var(--gray-200);
+  border-radius: 8px;
+  margin-bottom: 0.75rem;
+  background-color: white;
+  transition: var(--transition);
+  animation: fadeIn 0.3s ease;
+}
+
+.ruleItem:hover {
+  box-shadow: var(--shadow);
+  transform: translateY(-1px);
+}
+
+.ruleItem.disabled {
+  opacity: 0.6;
+  background-color: var(--gray-50);
+}
+
+.ruleContent {
+  display: flex;
+  align-items: center;
+  padding: 1rem;
+  gap: 1rem;
+}
+
+.ruleOrder {
+  background-color: var(--primary-color);
+  color: white;
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.875rem;
+  font-weight: 600;
+  flex-shrink: 0;
+}
+
+.ruleText {
+  flex: 1;
+  min-width: 0;
+}
+
+.searchText, .replaceText {
+  font-size: 0.875rem;
+  margin-bottom: 0.25rem;
+  word-break: break-word;
+}
+
+.searchText {
+  color: var(--gray-900);
+}
+
+.replaceText {
+  color: var(--gray-600);
+}
+
+.ruleActions {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  flex-shrink: 0;
+}
+
+/* ボタンスタイル */
+.toggleButton {
+  padding: 0.375rem 0.75rem;
+  border: 1px solid;
+  border-radius: 6px;
+  font-size: 0.75rem;
+  cursor: pointer;
+  transition: var(--transition);
+}
+
+.toggleButton.enabled {
+  background-color: var(--success-color);
+  border-color: var(--success-color);
+  color: white;
+}
+
+.toggleButton.enabled:hover {
+  background-color: var(--success-hover);
+  border-color: var(--success-hover);
+}
+
+.toggleButton.disabled {
+  background-color: var(--gray-300);
+  border-color: var(--gray-300);
+  color: var(--gray-600);
+}
+
+.toggleButton.disabled:hover {
+  background-color: var(--gray-400);
+  border-color: var(--gray-400);
+}
+
+.editButton {
+  padding: 0.375rem 0.75rem;
+  border: 1px solid var(--gray-300);
+  background-color: white;
+  color: var(--gray-700);
+  border-radius: 6px;
+  font-size: 0.75rem;
+  cursor: pointer;
+  transition: var(--transition);
+}
+
+.editButton:hover {
+  background-color: var(--gray-50);
+  border-color: var(--gray-400);
+}
+
+.moveButtons {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.moveButton {
+  padding: 0.125rem 0.375rem;
+  border: 1px solid var(--gray-300);
+  background-color: white;
+  color: var(--gray-600);
+  border-radius: 4px;
+  font-size: 0.75rem;
+  cursor: pointer;
+  transition: var(--transition);
+  line-height: 1;
+}
+
+.moveButton:hover:not(:disabled) {
+  background-color: var(--gray-50);
+  border-color: var(--gray-400);
+}
+
+.moveButton:disabled {
+  opacity: 0.3;
+  cursor: not-allowed;
+}
+
+.deleteButton {
+  padding: 0.375rem 0.75rem;
+  border: 1px solid var(--danger-color);
+  background-color: var(--danger-color);
+  color: white;
+  border-radius: 6px;
+  font-size: 0.75rem;
+  cursor: pointer;
+  transition: var(--transition);
+}
+
+.deleteButton:hover {
+  background-color: var(--danger-hover);
+  border-color: var(--danger-hover);
+}
+
+/* フォーム */
+.ruleForm {
+  border: 1px solid var(--gray-200);
+  border-radius: 8px;
+  padding: 1.5rem;
+  background-color: var(--gray-50);
+  margin-bottom: 1rem;
+  animation: fadeIn 0.3s ease;
+}
+
+.ruleForm h4 {
+  margin: 0 0 1rem 0;
+  font-size: 1rem;
+  color: var(--gray-900);
+}
+
+.formGroup {
+  margin-bottom: 1rem;
+}
+
+.formGroup label {
+  display: block;
+  margin-bottom: 0.5rem;
+  font-size: 0.875rem;
+  font-weight: 500;
+  color: var(--gray-700);
+}
+
+.input {
+  width: 100%;
+  padding: 0.75rem;
+  border: 1px solid var(--gray-300);
+  border-radius: 6px;
+  font-size: 0.875rem;
+  transition: var(--transition);
+  background-color: white;
+}
+
+.input:focus {
+  outline: none;
+  border-color: var(--primary-color);
+  box-shadow: 0 0 0 3px rgba(79, 70, 229, 0.1);
+}
+
+.input::placeholder {
+  color: var(--gray-400);
+}
+
+.formActions {
+  display: flex;
+  gap: 0.75rem;
+  justify-content: flex-end;
+}
+
+.submitButton {
+  padding: 0.75rem 1.5rem;
+  background-color: var(--primary-color);
+  color: white;
+  border: none;
+  border-radius: 6px;
+  font-size: 0.875rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition: var(--transition);
+}
+
+.submitButton:hover {
+  background-color: var(--primary-hover);
+}
+
+.cancelButton {
+  padding: 0.75rem 1.5rem;
+  background-color: white;
+  color: var(--gray-700);
+  border: 1px solid var(--gray-300);
+  border-radius: 6px;
+  font-size: 0.875rem;
+  cursor: pointer;
+  transition: var(--transition);
+}
+
+.cancelButton:hover {
+  background-color: var(--gray-50);
+  border-color: var(--gray-400);
+}
+
+/* 追加ボタン */
+.addButton {
+  width: 100%;
+  padding: 1rem;
+  background-color: var(--primary-color);
+  color: white;
+  border: none;
+  border-radius: 8px;
+  font-size: 0.875rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition: var(--transition);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+}
+
+.addButton:hover {
+  background-color: var(--primary-hover);
+  transform: translateY(-1px);
+}
+
+/* レスポンシブデザイン */
+@media (max-width: 768px) {
+  .replacementSection {
+    padding: 1rem;
+  }
+
+  .header {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.5rem;
+  }
+
+  .rulesHeader {
+    flex-direction: column;
+    gap: 0.75rem;
+    align-items: flex-start;
+  }
+
+  .bulkActions {
+    flex-wrap: wrap;
+  }
+
+  .ruleContent {
+    flex-direction: column;
+    gap: 0.75rem;
+    align-items: flex-start;
+  }
+
+  .ruleActions {
+    flex-wrap: wrap;
+    justify-content: flex-start;
+  }
+
+  .formActions {
+    flex-direction: column;
+  }
+
+  .submitButton, .cancelButton {
+    width: 100%;
+  }
+} 

--- a/hooks/useStringReplacement.js
+++ b/hooks/useStringReplacement.js
@@ -1,0 +1,195 @@
+import { useState, useEffect } from 'react';
+
+export const useStringReplacement = () => {
+  const [replacementRules, setReplacementRules] = useState([]);
+  const [error, setError] = useState('');
+
+  // LocalStorageからの読み込み
+  useEffect(() => {
+    try {
+      const saved = localStorage.getItem('csvConverter_replacementRules');
+      if (saved) {
+        const rules = JSON.parse(saved);
+        setReplacementRules(rules);
+      }
+    } catch (err) {
+      console.error('Failed to load replacement rules:', err);
+      setError('置換ルールの読み込みに失敗しました');
+    }
+  }, []);
+
+  // LocalStorageへの保存
+  const saveRules = (rules) => {
+    try {
+      localStorage.setItem('csvConverter_replacementRules', JSON.stringify(rules));
+      setReplacementRules(rules);
+      setError('');
+    } catch (err) {
+      console.error('Failed to save replacement rules:', err);
+      setError('置換ルールの保存に失敗しました');
+    }
+  };
+
+  // バリデーション関数
+  const validateRule = (searchText, replaceText, excludeId = null) => {
+    if (!searchText || searchText.trim() === '') {
+      return '検索する文字列を入力してください';
+    }
+
+    // 重複チェック
+    const isDuplicate = replacementRules.some(rule => 
+      rule.id !== excludeId && rule.searchText === searchText
+    );
+    if (isDuplicate) {
+      return '同じ検索文字列が既に存在します';
+    }
+
+    return null;
+  };
+
+  // ルールの追加
+  const addRule = (searchText, replaceText) => {
+    const validationError = validateRule(searchText, replaceText);
+    if (validationError) {
+      setError(validationError);
+      return false;
+    }
+
+    const newRule = {
+      id: `rule_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`,
+      searchText: searchText.trim(),
+      replaceText: replaceText || '',
+      isEnabled: true,
+      order: replacementRules.length
+    };
+
+    const newRules = [...replacementRules, newRule];
+    saveRules(newRules);
+    return true;
+  };
+
+  // ルールの更新
+  const updateRule = (id, searchText, replaceText) => {
+    const validationError = validateRule(searchText, replaceText, id);
+    if (validationError) {
+      setError(validationError);
+      return false;
+    }
+
+    const newRules = replacementRules.map(rule =>
+      rule.id === id
+        ? { ...rule, searchText: searchText.trim(), replaceText: replaceText || '' }
+        : rule
+    );
+    saveRules(newRules);
+    return true;
+  };
+
+  // ルールの削除
+  const deleteRule = (id) => {
+    const newRules = replacementRules.filter(rule => rule.id !== id);
+    // 削除後の並び順を調整
+    const reorderedRules = newRules.map((rule, index) => ({
+      ...rule,
+      order: index
+    }));
+    saveRules(reorderedRules);
+  };
+
+  // ルールの有効/無効切り替え
+  const toggleRule = (id) => {
+    const newRules = replacementRules.map(rule =>
+      rule.id === id ? { ...rule, isEnabled: !rule.isEnabled } : rule
+    );
+    saveRules(newRules);
+  };
+
+  // 全てのルールの有効/無効切り替え
+  const toggleAllRules = (enabled) => {
+    const newRules = replacementRules.map(rule => ({
+      ...rule,
+      isEnabled: enabled
+    }));
+    saveRules(newRules);
+  };
+
+  // ルールの並び順変更
+  const reorderRules = (fromIndex, toIndex) => {
+    const newRules = [...replacementRules];
+    const [reorderedRule] = newRules.splice(fromIndex, 1);
+    newRules.splice(toIndex, 0, reorderedRule);
+    
+    // 並び順を更新
+    const reorderedRules = newRules.map((rule, index) => ({
+      ...rule,
+      order: index
+    }));
+    saveRules(reorderedRules);
+  };
+
+  // 全ルールの削除
+  const clearAllRules = () => {
+    saveRules([]);
+  };
+
+  // 置換処理の適用
+  const applyReplacements = (content) => {
+    if (!content || replacementRules.length === 0) {
+      return { processedContent: content, stats: { totalReplacements: 0, appliedRules: [] } };
+    }
+
+    let processedContent = content;
+    const stats = { totalReplacements: 0, appliedRules: [] };
+
+    // 有効なルールのみを順番に適用
+    const enabledRules = replacementRules
+      .filter(rule => rule.isEnabled)
+      .sort((a, b) => a.order - b.order);
+
+    for (const rule of enabledRules) {
+      try {
+        const beforeCount = (processedContent.match(new RegExp(escapeRegExp(rule.searchText), 'g')) || []).length;
+        if (beforeCount > 0) {
+          processedContent = processedContent.replace(
+            new RegExp(escapeRegExp(rule.searchText), 'g'),
+            rule.replaceText
+          );
+          stats.totalReplacements += beforeCount;
+          stats.appliedRules.push({
+            searchText: rule.searchText,
+            replaceText: rule.replaceText,
+            count: beforeCount
+          });
+        }
+      } catch (err) {
+        console.error('Error applying replacement rule:', err);
+      }
+    }
+
+    return { processedContent, stats };
+  };
+
+  // 正規表現のエスケープ関数
+  const escapeRegExp = (string) => {
+    return string.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  };
+
+  // エラーのクリア
+  const clearError = () => {
+    setError('');
+  };
+
+  return {
+    replacementRules,
+    error,
+    addRule,
+    updateRule,
+    deleteRule,
+    toggleRule,
+    toggleAllRules,
+    reorderRules,
+    clearAllRules,
+    applyReplacements,
+    clearError
+  };
+}; 

--- a/styles/Home.module.css
+++ b/styles/Home.module.css
@@ -301,6 +301,42 @@
   color: var(--gray-900);
 }
 
+/* 置換統計表示 */
+.replacementStats {
+  background-color: #f0f9ff;
+  border: 1px solid #0ea5e9;
+  border-radius: 8px;
+  padding: 1rem;
+  margin-bottom: 1.5rem;
+  animation: fadeIn 0.5s ease;
+}
+
+.replacementStats h4 {
+  margin: 0 0 0.5rem 0;
+  color: #0369a1;
+  font-size: 1rem;
+}
+
+.replacementStats p {
+  margin: 0 0 0.75rem 0;
+  color: #0369a1;
+  font-weight: 500;
+}
+
+.replacementDetails {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.replacementDetail {
+  font-size: 0.875rem;
+  color: #075985;
+  padding: 0.25rem 0.5rem;
+  background-color: #e0f2fe;
+  border-radius: 4px;
+}
+
 @media (max-width: 768px) {
   .main {
     padding: 2rem 1rem;


### PR DESCRIPTION
## 概要

- 文字列置換機能の追加
  - ローカルでの設定の永続化
- 処理フロー
CSV アップロード → JIS→UTF変換 → 文字列置換適用 → ダウンロード
- 

## 対応チケット
- CU-86eu3grza(親チケット：CU-86eu29utv)

## テスト

- [x] 文字列が置換していることを確認
上：機能実装前、下：機能実装後
<img width="995" alt="スクリーンショット 2025-07-08 15 16 18" src="https://github.com/user-attachments/assets/54d3355b-b8c8-4900-85e3-4444941b496a" />
<img width="1172" alt="スクリーンショット 2025-07-08 15 16 44" src="https://github.com/user-attachments/assets/fe8d6b30-901c-4a23-95ae-d618c09b517b" />

- [x] CSVファイルがUTF-8に変換されていることを確認
 - VSCodeで変換後ファイルをエンコード付きで開いた際UTF-8の時は文字化けせず、JISで開いた場合は文字化けすることを確認
 - 変換前ファイルはエンコード付きで開いた際UTF-8の時は文字化けし、JISで開いた場合は文字化けしない
- [x] ローカルでの設定の永続化を確認
 - ページリロード後も設定が残っている
- [x] 永続化している設定を無効にして変換した際ダウンロードしたファイルに設定が反映されないことを確認